### PR TITLE
Update role binding namespace

### DIFF
--- a/odo-RBAC/codewind-odoclusterrolebinding.yaml
+++ b/odo-RBAC/codewind-odoclusterrolebinding.yaml
@@ -15,7 +15,7 @@ metadata:
   name: codewind-odoclusterrolebinding
 subjects:
 - kind: ServiceAccount
-  namespace: eclipse-che
+  namespace: che
   name: che-workspace
 roleRef:
   kind: ClusterRole


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/648

This PR is for:
Update the namespace to `che` by default, that is where chectl installs by default.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>