### PR TITLE
Fix app/build logs with the new logs architecture

### DIFF
--- a/.odo-extension-config.json
+++ b/.odo-extension-config.json
@@ -1,11 +1,17 @@
 {
     "requiredFiles": [],
-    "buildLogs": [
-        "odo.build"
-    ],
-    "appLogs": [
-        "odo.app"
-    ],
+    "appWorkspaceLogs": {
+        "files": {
+            "odo.app": null
+        }
+    },
+    "appContainerLogs": {},
+    "buildWorkspaceLogs": {
+         "files": {
+            "odo.build": null
+        }
+     },
+    "buildContainerLogs": {},
     "capabilities": {
         "startModes": [ 
             "run"


### PR DESCRIPTION
With the new logs architecture https://github.com/eclipse/codewind/pull/899, we will need this small change on the extension files to work correctly.

This PR needs to wait till https://github.com/eclipse/codewind/pull/899 goes in.

Check for similar PR in appsody as well https://github.com/eclipse/codewind-appsody-extension/pull/54

Signed-off-by: ssh24 <sakib@ibm.com>