### PR TITLE
[0.6.0] Fix get pod name function

### DIFF
--- a/scripts/odo-util.sh
+++ b/scripts/odo-util.sh
@@ -28,7 +28,7 @@ function getAppName() {
 }
 
 function getPodName() {
-    POD_NAME=$(kubectl get po -o name --selector=deploymentconfig=$COMPONENT_NAME-$APP_NAME)
+    POD_NAME=$(kubectl get po -o name --selector=deploymentconfig=cw-$COMPONENT_NAME-$APP_NAME)
     echo $POD_NAME
 }
 


### PR DESCRIPTION
Issue: eclipse/codewind#1083

This PR is for fixing get pod name function so that OpenShift projects won't get stuck.

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>