### PR TITLE
Setup for hybrid case

### DIFF
--- a/setup/codewind-odorolebinding.yaml
+++ b/setup/codewind-odorolebinding.yaml
@@ -9,14 +9,13 @@
 #     IBM Corporation - initial API and implementation
 #*******************************************************************************
 
-kind: ClusterRoleBinding
+kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: codewind-odoclusterrolebinding
+  name: codewind-odorolebinding
 subjects:
 - kind: ServiceAccount
-  namespace: che
-  name: che-workspace
+  name: <serviceaccount>
 roleRef:
   kind: ClusterRole
   name: codewind-odoclusterrole

--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+###################################################################################
+# Copyright (c) 2019 IBM Corporation and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v2.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v20.html
+#
+# Contributors:
+#     IBM Corporation - initial API and implementation
+###################################################################################
+
+# Bind (rolebinding) additional cluster roles to Codewind service account(s)
+SERVICE_ACCOUNTS=$(kubectl get po --selector=app=codewind-pfe -o jsonpath='{.items[*].spec.containers[*].env[?(@.name=="SERVICE_ACCOUNT_NAME")].value}')
+for SERVICE_ACCOUNT in $SERVICE_ACCOUNTS; do
+    echo "Bind (rolebinding) additional cluster roles to Codewind service account: $SERVICE_ACCOUNT"
+    sed -i ' ' "s/<serviceaccount>/$SERVICE_ACCOUNT/g" codewind-odorolebinding.yaml
+    kubectl apply -f codewind-odoclusterrole.yaml
+    kubectl apply -f codewind-odorolebinding.yaml
+done
+
+# Import Java image stream to the cluster
+./odo-addbuilder.sh


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/1375

This PR is for adding setup script to:
- Dynamically get the service account name(s) of hybrid Codewind, then apply additional roles to the specific service account name(s) for supporting odo
- Import Java image stream

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>