### PR TITLE
[0.8.0] Make odo setup script support all platforms

### DIFF
--- a/setup/setup.sh
+++ b/setup/setup.sh
@@ -10,11 +10,19 @@
 #     IBM Corporation - initial API and implementation
 ###################################################################################
 
+OS=$(uname -a | awk '{print $1;}')
+
 # Bind (rolebinding) additional cluster roles to Codewind service account(s)
 SERVICE_ACCOUNTS=$(kubectl get po --selector=app=codewind-pfe -o jsonpath='{.items[*].spec.containers[*].env[?(@.name=="SERVICE_ACCOUNT_NAME")].value}')
 for SERVICE_ACCOUNT in $SERVICE_ACCOUNTS; do
     echo "Bind (rolebinding) additional cluster roles to Codewind service account: $SERVICE_ACCOUNT"
-    sed -i ' ' "s/<serviceaccount>/$SERVICE_ACCOUNT/g" codewind-odorolebinding.yaml
+
+    if [ $OS == "Darwin" ]; then
+        sed -i ' ' "s/<serviceaccount>/$SERVICE_ACCOUNT/g" codewind-odorolebinding.yaml
+    elif [ $OS == "Linux" ]; then
+        sed -i "s/<serviceaccount>/$SERVICE_ACCOUNT/g" codewind-odorolebinding.yaml
+    fi
+
     kubectl apply -f codewind-odoclusterrole.yaml
     kubectl apply -f codewind-odorolebinding.yaml
 done


### PR DESCRIPTION
Issue: https://github.com/eclipse/codewind/issues/1787

This PR is for making odo setup script support all platforms (eg. Mac and Linux).

Signed-off-by: jingfu wang <jingfu.j.wang@ibm.com>