### PR TITLE
Add projectID labels to deploymentconfig, service and route

### DIFF
--- a/odo-extension-entrypoint.sh
+++ b/odo-extension-entrypoint.sh
@@ -113,6 +113,15 @@ function create() {
 		echo -e "\nFailed to add owner references for all resources deployed by odo\n" |& tee -a $ODO_DEBUG_LOG
 		exit 3
 	fi
+
+	echo "Adding projectID label for all resources deployed by odo" |& tee -a $ODO_DEBUG_LOG
+	$odoUtil addProjectIDLabel $COMPONENT_NAME $APP_NAME $ODO_DEBUG_LOG $PROJECT_ID
+	if [ $? -eq 0 ]; then
+		echo -e "\nSuccessfully added projectID label for all resources deployed by odo\n" |& tee -a $ODO_DEBUG_LOG
+	else
+		echo -e "\nFailed to add projectID label for all resources deployed by odo\n" |& tee -a $ODO_DEBUG_LOG
+		exit 3
+	fi
 }
 
 function remove() {


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [ ] Bug fix
- [x] Enhancement

## What does this PR do ?
On an `odo` create it adds the `projectID` as a label to the deploymentconfig, service and route. These are used by PFE to determine the address for load testing and codewind linking.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/3019 and https://github.com/eclipse/codewind/issues/2999

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
