### PR TITLE
fix: stop getRepositories returning before index.json is created 

### DIFF
--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * 
+ *
  * Copyright (c) 2019 IBM Corporation and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v2.0
@@ -8,15 +8,17 @@
  *
  * Contributors:
  *     IBM Corporation - initial API and implementation
- * 
+ *
  *******************************************************************************/
-
 'use strict';
 
 const { exec } = require('child_process');
-const os = require('os');
-const fs = require('fs');
+const { promisify } = require('util');
+const { readFile, writeFile } = require('fs');
 
+const execAsync = promisify(exec);
+const readFileAsync = promisify(readFile);
+const writeFileAsync = promisify(writeFile);
 
 const CODEWIND_ODO_EXTENSION_BASE_PATH = '/codewind-workspace/.extensions/codewind-odo-extension';
 const MASTER_INDEX_JSON_FILE = CODEWIND_ODO_EXTENSION_BASE_PATH + '/templates/master-index.json';
@@ -27,109 +29,58 @@ const ODO_CATALOG_LIST_COMMAND = CODEWIND_ODO_EXTENSION_BASE_PATH + '/bin/odo ca
 
 module.exports = {
     getRepositories: async function() {
-        return new Promise((resolve, reject) => {
+        // Read master-index.json of currently defined templates for OpenShift
+        const data = await readFileAsync(MASTER_INDEX_JSON_FILE, 'utf8');
+        const masterjson = JSON.parse(data);
 
-            // Read master-index.json of currently defined templates for OpenShift
-            fs.readFile(MASTER_INDEX_JSON_FILE, 'utf8', function (err, data) {
-                if (err)
-                    return reject(err);
-        
-                const masterjson = JSON.parse(data);
+        // Get the current list of components from the ODO command
+        const { stdout } = await execAsync(ODO_CATALOG_LIST_COMMAND);
+        const { items } = JSON.parse(stdout);
+        const odocomponents = items.map(({ metadata: { name }}) => name);
 
-                // Run odo command to get list of catalog components available for cluster, then compare with mater index.json
-                // to generate updated index.json used for project creation
-                const odocomponents = [];
-                exec(ODO_CATALOG_LIST_COMMAND, (err, stdout) => {
-                    if (err)
-                        return reject(err);
+        // Loop through current list of templates in master index.json and delete any language
+        // not in component list returned by odo command
+        // note: the master index.json is assumed to use same keywords for 'language' as odo uses for component 'name'
+        const sanitisedComponents = masterjson.filter(({ language }) => odocomponents.includes(language));
 
-                    const componentsjson = JSON.parse(stdout);
+        await writeFileAsync(RECONCILED_INDEX_JSON_FILE, JSON.stringify(sanitisedComponents, null, 4), 'utf8');
 
-                    for (const component of componentsjson.items) {
-                        odocomponents.push(component.metadata.name);
-                    }
-
-                    // Loop through current list of templates in master index.json and delete any language 
-                    // not in component list returned by odo command
-                    // note: the master index.json is assumed to use same keywords for 'language' as odo uses for component 'name'
-                    for(var i = 0; i < masterjson.length; i++) {
-                        if ( !odocomponents.includes(masterjson[i].language) ) {
-                            masterjson.splice(i,1);
-                        }
-                    }
-
-                    // Write out reconciled index.json file
-                    const reconciledjsoncontent = JSON.stringify(masterjson, null, 3);
-                    try {
-                        fs.writeFileSync(RECONCILED_INDEX_JSON_FILE, reconciledjsoncontent, 'utf8');
-                    }
-                    catch (e) {
-                        return reject(e);
-                    }
-                });
-            });
-            
-            // Return a link to the updated index.json index
-            const repos = [];
-            const projectStylesArr = [];
-            projectStylesArr.push('OpenShift')
-            repos.push({
-                name: 'OpenShift templates',
-                description: 'The set of templates for new OpenShift projects in Codewind.',
-                url: JSON_FILE_URL,
-                projectStyles: projectStylesArr
-            });
-            resolve(repos);
-        });
+        // Return a link to the updated index.json index
+        const repos = [{
+            name: 'OpenShift Devfile templates',
+            description: 'The set of templates for new OpenShift Devfile projects in Codewind.',
+            url: JSON_FILE_URL,
+            projectStyles: ['OpenShift Devfiles'],
+        }];
+        return repos;
     },
 
     getProjectTypes: async function() {
-        return new Promise((resolve, reject) => {
-            const projectTypes = [];
+        // Read master-index.json of currently defined templates for OpenShift
+        const data = await readFileAsync(MASTER_INDEX_JSON_FILE, 'utf8');
+        const masterjson = JSON.parse(data);
 
-            // Read master-index.json of currently defined templates for OpenShift
-            fs.readFile(MASTER_INDEX_JSON_FILE, 'utf8', function (err, data) {
-                if (err)
-                    return reject(err);
-        
-                const masterjson = JSON.parse(data);
+        // Run odo command to get list of catalog components available for cluster, then compare with mater index.json
+        // to generate supported language for project bind
+        const { stdout } = await execAsync(ODO_CATALOG_LIST_COMMAND);
+        const { items } = JSON.parse(stdout);
+        const odocomponents = items.map(({ metadata: { name }}) => name);
 
-                // Run odo command to get list of catalog components available for cluster, then compare with mater index.json
-                // to generate supported language for project bind
-                const odocomponents = [];
-                exec(ODO_CATALOG_LIST_COMMAND, (err, stdout) => {
-                    if (err)
-                        return reject(err);
-    
-                    const componentsjson = JSON.parse(stdout);
-
-                    for (const component of componentsjson.items) {
-                        odocomponents.push(component.metadata.name);
-                    }
-
-                    // Loop through current list of templates in master index.json and add any language 
-                    // that in component list returned by odo command
-                    // note: the master index.json is assumed to use same keywords for 'language' as odo uses for component 'name'
-                    for(var i = 0; i < masterjson.length; i++) {
-                        if ( !odocomponents.includes(masterjson[i].language) ) {
-                            continue;
-                        } else {
-                            projectTypes.push({
-                                projectType: 'odo',
-                                projectSubtypes: {
-                                    label: 'OpenShift component',
-                                    items: [{
-                                        id: `OpenShift/${masterjson[i].language}`,
-                                        label: `OpenShift ${masterjson[i].language}`,
-                                        description: masterjson[i].description
-                                    }]
-                                }
-                            });
-                        }
-                    }
-                    resolve(projectTypes);
-                });
-            });
-        });
+        // Loop through current list of templates in master index.json and add any language
+        // that in component list returned by odo command
+        // note: the master index.json is assumed to use same keywords for 'language' as odo uses for component 'name'
+        const projectTypes = masterjson.filter(({ language }) => odocomponents.includes(language))
+            .map(({ language, description }) => ({
+                projectType: 'odo',
+                projectSubtypes: {
+                    label: 'OpenShift component',
+                    items: [{
+                        id: `OpenShift/${language}`,
+                        label: `OpenShift ${language}`,
+                        description,
+                    }],
+                },
+            }));
+        return projectTypes;
     }
 }


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Fixes a bug where the `getRepositories` function would return before the `index.json` file is created. This causes PFE to not get the Openshift templates.

Not sure if its worth getting this into 0.13 if it's not too late.

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/3133

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
