### PR TITLE
Change metadata of template repository

### DIFF
--- a/templatesProvider.js
+++ b/templatesProvider.js
@@ -47,10 +47,10 @@ module.exports = {
 
         // Return a link to the updated index.json index
         const repos = [{
-            name: 'OpenShift Devfile templates',
-            description: 'The set of templates for new OpenShift Devfile projects in Codewind.',
+            name: 'OpenShift templates',
+            description: 'The set of templates for new OpenShift projects in Codewind.',
             url: JSON_FILE_URL,
-            projectStyles: ['OpenShift Devfiles'],
+            projectStyles: ['OpenShift'],
         }];
         return repos;
     },


### PR DESCRIPTION
Signed-off-by: James Wallis <james.wallis1@ibm.com>

## What type of PR is this ? 

- [x] Bug fix
- [ ] Enhancement

## What does this PR do ?
Reverts the repository name and description to `Openshift` rather than `Openshift Devfiles`.
Accidentally changed in: https://github.com/eclipse/codewind-odo-extension/commit/9e4ec4b8e037c1a2ff0f6848bd3287e82859721e#diff-3064a823f4b75cd4acd5f2b014af4c0fR49

## Which issue(s) does this PR fix ?

#### Link to the [Codewind repository](https://github.com/eclipse/codewind/issues) issue(s) this PR fixes or references: https://github.com/eclipse/codewind/issues/3164

## Does this PR require a documentation change ?


## Any special notes for your reviewer ?
